### PR TITLE
Improve error diagnostic on fs error

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -89,11 +89,15 @@ impl InstructionReader for FileSystem {
                 let mut file = File::create(self.source.join(&filename)).unwrap_or_else(|error| {
                     panic!("can't create file {:?}: {:?}", filename, error)
                 });
-                file.write_all(&contents).expect("can't write file");
+                file.write_all(&contents).unwrap_or_else(|error| {
+                    panic!("can't write to file {:?} due to {:?}", filename, error)
+                });
             }
 
             Instruction::CreateFolder { folder } => {
-                fs::create_dir_all(self.source.join(folder)).expect("can't write folder");
+                fs::create_dir_all(self.source.join(&folder)).unwrap_or_else(|error| {
+                    panic!("can't write to folder {:?}: {:?}", folder, error)
+                });
             }
         }
     }


### PR DESCRIPTION
This lets the user know which file/folder failed to write.

In the future, perhaps a more persistent rbxlx-to-rojo would be good, where it skips the current directory/file and outputs all the failed directories/files at the end of the program.